### PR TITLE
Nanny Improvements

### DIFF
--- a/src/Nanny.StorageQueue/StorageQueueClient.cs
+++ b/src/Nanny.StorageQueue/StorageQueueClient.cs
@@ -2,6 +2,7 @@
 using Microsoft.WindowsAzure.Storage.Queue;
 using Nanny.Common.Interfaces;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Nanny.StorageQueue
@@ -55,6 +56,11 @@ namespace Nanny.StorageQueue
             {
                 await _queue.FetchAttributesAsync();
                 count = _queue.ApproximateMessageCount;
+
+                List<CloudQueueMessage> messages = (List<CloudQueueMessage>) await _queue.PeekMessagesAsync(count.Value);
+
+                if (messages.Count < 32)
+                    count = messages.Count;
 
                 Console.WriteLine($"The queue {queueName} has  {count} message(s)!");
 

--- a/src/QueueStorage.Consumer/Program.cs
+++ b/src/QueueStorage.Consumer/Program.cs
@@ -155,7 +155,8 @@ namespace QueueStorage.Consumer
 
             var queue = await CreateQueueAsync(undequeue);
 
-            await queue.AddMessageAsync(message);
+            var dequeueMessage = new CloudQueueMessage(message.AsString);
+            await queue.AddMessageAsync(dequeueMessage);
 
             await _queue.DeleteMessageAsync(message);
         }

--- a/src/QueueStorage.Consumer/settings.json
+++ b/src/QueueStorage.Consumer/settings.json
@@ -4,7 +4,7 @@
   "TEMP_FOLDER": "pdfimages",
   "IMAGE_RESOLUTION": "4096",
   "STORAGE_ACCOUNT": "DefaultEndpointsProtocol=https;AccountName=imagepdfcasacivil;AccountKey=AdCG0SBxp81sGwi8fcKPC1usikIlsS/jrlrun4XEV4RSdEIIabBMGzefHOq2MTXis1lA1KhNyT0tpptusCn8pw==;EndpointSuffix=core.windows.net",
-  "QUEUE_NAME": "pdftoimagehigh",
+  "QUEUE_NAME": "pdftoimage",
   "IMAGE_STORAGE_ACCOUNT": "DefaultEndpointsProtocol=https;AccountName=imagepdfcasacivil;AccountKey=AdCG0SBxp81sGwi8fcKPC1usikIlsS/jrlrun4XEV4RSdEIIabBMGzefHOq2MTXis1lA1KhNyT0tpptusCn8pw==;EndpointSuffix=core.windows.net",
-  "IMAGE_CONTAINER_NAME": "pdfimageshigh"
+  "IMAGE_CONTAINER_NAME": "pdfimages"
 }

--- a/src/library/Nanny.Kubernetes/Interfaces/IKubeScaling.cs
+++ b/src/library/Nanny.Kubernetes/Interfaces/IKubeScaling.cs
@@ -11,7 +11,7 @@ namespace Nanny.Kubernetes.Interfaces
         Task<V1Deployment> UpdateDeploymentAsync(V1Deployment deployment);
 
         //Jobs
-        Task<V1Job> CreateJobAsync(string jobName, int parallelism, int completions, string containerName, string containerImage, string imagePullSecret, string _namespace);
+        Task<V1Job> CreateJobAsync(string jobName, int parallelism, int completions, string containerName, string containerImage, string imagePullSecret, string label, string _namespace);
 
         //Kluster
         Task<bool> isResourceAvailableAsync();


### PR DESCRIPTION
fixes #8 
I used the method peekmessages to retrive the first 32 messages (limited) by the sdk for a single request.
if the count of message is less then 32 I use the number from the peekmessage

fixes #7 
Added label when created a job and to check the number of pods running (status Running and Pending)
